### PR TITLE
fix(Docker): Change parameter type in deploy template

### DIFF
--- a/azure-deploy.example.parameters.json
+++ b/azure-deploy.example.parameters.json
@@ -18,7 +18,7 @@
       "value": "20221231"
     },
     "issReportingYear": {
-      "value": 2021
+      "value": "2021"
     },
     "PGPASSWORD": {
       "value": "Super5ecret!"

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -35,7 +35,7 @@
       }
     },
     "issReportingYear": {
-      "type": "integer",
+      "type": "string",
       "metadata": {
         "description": "Reporting year to use for ISS data."
       }


### PR DESCRIPTION
`integer` was not recognizing as a valid type on running the deploy template, so converting to `string`