### PR TITLE
Change DB Size, export logs

### DIFF
--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -89,7 +89,7 @@
     },
     "restartPolicy": {
       "type": "string",
-      "defaultValue": "OnFailure",
+      "defaultValue": "Never",
       "allowedValues": [
         "Always",
         "Never",
@@ -110,6 +110,18 @@
       "type": "securestring",
       "metadata": {
         "description": "The storage account key for the rawdata storage account."
+      }
+    },
+    "workspaceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The ID for a Log Analytics Workspace."
+      }
+    },
+    "workspaceKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The key for a Log Analytics Workspace."
       }
     },
     "updateDB": {
@@ -133,7 +145,7 @@
     "dbInstanceType": "Standard_D2ds_v4",
     "dbServerEdition": "GeneralPurpose",
     "dbServerName": "[concat(parameters('containerGroupName'), '-postgres')]",
-    "dbSkuSizeGB": 256,
+    "dbSkuSizeGB": 512,
     "machineCpuCoresLimitLoader": 3,
     "machineCpuCoresLimitWorkflow": 2,
     "machineCpuCoresRequestLoader": 2,
@@ -344,6 +356,13 @@
         "[if(parameters('updateDB'), resourceId('Microsoft.DBforPostgreSQL/flexibleServers', variables('dbServerName')), '')]"
       ],
       "properties": {
+        "diagnostics": {
+          "logAnalytics": {
+            "logType": "ContainerInstanceLogs",
+            "workspaceId": "[parameters('workspaceId')]]",
+            "workspaceKey": "[parameters('workspaceKey')]"
+          }
+        },
         "containers":
         "[concat(variables('ContainerDefinitionWorkflow'), if(parameters('updateDB'), variables('ContainerDefinitionLoader'), variables('emptyArray')))]",
         "restartPolicy": "[parameters('restartPolicy')]",


### PR DESCRIPTION
When running on an azure container instance, if the machine restarts or terminates on failure, ACI drops the logs. The big change here is the inclusion of the Log Analytics Workspace credentials (ID and Key), which allow the container to stream those logs to an external store for posthumous inspection.

----

Additionally, upon inspection of said logs, discovered an interaction between FDSLoader application and Azure
PostgreSQL flexible server's "autogrow" functionality.

Postgres Database was running out of space, even though the PostgreSQL database is set to automatically expand storage, because autogrow increases the space limit when there's less than 10GB available, but that assumes you're not trying to INSERT or UPDATE a table and do more than 10Gb of operations all in one go (which it seems the Loader does).

Bumping to 512 resolved issue, and process ran smoothly.