### PR TITLE
test(package): #41 Add infrastructure for manual testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 azure-deploy.parameters.json
+factset-extracted/

--- a/README.md
+++ b/README.md
@@ -151,7 +151,21 @@ az deployment group create --resource-group "$RESOURCEGROUP" --template-file azu
 
 ```
 
-## Local Testing
+## Local Development
+
+### Build
+
+Note that the image supports `amd64` platforms.
+If you are running on an `arm64` machine (Apple Silicon), you may need to change the preferrred build platform with:
+
+```sh
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+To build the image, you can use the standard mechanism of `docker build .`.
+To build and test in one step, you can alternately use `docker-compose up --build`
+
+### Testing
 
 Partial (manual) local testing is possible via `docker-compose`.
 Currently `get_issue_code_bridge()` is the sole function with necessary testing infrastructure.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,38 @@ az deployment group create --resource-group "$RESOURCEGROUP" --template-file azu
 
 ```
 
+## Local Testing
+
+Partial (manual) local testing is possible via `docker-compose`.
+Currently `get_issue_code_bridge()` is the sole function with necessary testing infrastructure.
+
+Testing Steps:
+
+```sh
+docker-compose up
+```
+
+```sh
+# in another terminal:
+docker attach workflowfactset-workflow.factset-1 # enters the workflow.factset container
+```
+
+This enters the container, which is running R in an interactive session
+
+```r
+#in that container
+library(workflow.factset)
+conn <- connect_factset_db()
+issue_code_bridge <- get_issue_code_bridge(conn = conn)
+issue_code_bridge
+```
+
+From here, you can exit R as usual (`q()`), and then turn off the database container with:
+
+```sh
+docker-compose down --volumes
+```
+
 ## Exported Files
 
 The files exported by `workflow.factset::export_pacta_files()` are:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       PGUSER: postgres
     volumes:
       - type: bind
-        source: ./outputs
+        source: ./factset-extracted
         target: /mnt/factset-extracted
         read_only: false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+---
+services:
+  workflow.factset:
+    build: .
+    stdin_open: true
+    tty: true
+    command: ["R"]
+    environment:
+      DATA_TIMESTAMP: 20221231
+      DEPLOY_START_TIME: 20000101T000001
+      EXPORT_DESTINATION: /mnt/factset-loader
+      LOG_LEVEL: TRACE
+      MACHINE_CORES: 1
+      PGDATABASE: FDS
+      PGHOST: db
+      PGPASSWORD: SuperSecret1234
+      PGUSER: postgres
+    volumes:
+      - type: bind
+        source: ./outputs
+        target: /mnt/factset-extracted
+        read_only: false
+
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_PASSWORD: SuperSecret1234
+      POSTGRES_USER: postgres
+      POSTGRES_DB: FDS
+    volumes:
+      - type: bind
+        source: ./tests/sql/
+        target: /docker-entrypoint-initdb.d
+        read_only: true

--- a/tests/sql/001_schema.sql
+++ b/tests/sql/001_schema.sql
@@ -1,0 +1,6 @@
+SET client_encoding = 'UTF8';
+SELECT pg_catalog.set_config('search_path', '', false);
+
+CREATE SCHEMA fds;
+ALTER SCHEMA fds OWNER TO postgres;
+SET default_tablespace = '';

--- a/tests/sql/ref_v2_asset_class_map.sql
+++ b/tests/sql/ref_v2_asset_class_map.sql
@@ -1,0 +1,24 @@
+--
+-- TOC entry 278 (class 1259 OID 30953)
+-- Name: ref_v2_asset_class_map; Type: TABLE; Schema: fds; Owner: postgres
+--
+
+CREATE TABLE fds.ref_v2_asset_class_map (
+    asset_class_code character(1) NOT NULL COLLATE pg_catalog."C",
+    asset_class_desc character varying(25) NOT NULL COLLATE pg_catalog."C"
+);
+
+
+ALTER TABLE fds.ref_v2_asset_class_map OWNER TO postgres;
+
+ALTER TABLE ONLY fds.ref_v2_asset_class_map
+    ADD CONSTRAINT ref_v2_asset_class_map_pkey PRIMARY KEY (asset_class_code);
+
+INSERT INTO fds.ref_v2_asset_class_map (
+  asset_class_code,
+  asset_class_desc
+) VALUES
+  ('X', 'Bond'),
+  ('Y', 'Equity'),
+  ('Z', 'Other')
+  ;

--- a/tests/sql/ref_v2_issue_type_map.sql
+++ b/tests/sql/ref_v2_issue_type_map.sql
@@ -1,0 +1,31 @@
+--
+-- TOC entry 355 (class 1259 OID 31350)
+-- Name: ref_v2_issue_type_map; Type: TABLE; Schema: fds; Owner: postgres
+--
+
+CREATE TABLE fds.ref_v2_issue_type_map (
+    issue_type_code character(2) NOT NULL COLLATE pg_catalog."C",
+    issue_type_desc character varying(25) NOT NULL COLLATE pg_catalog."C",
+    asset_class_code character(1) COLLATE pg_catalog."C"
+);
+
+
+ALTER TABLE fds.ref_v2_issue_type_map OWNER TO postgres;
+ALTER TABLE ONLY fds.ref_v2_issue_type_map
+    ADD CONSTRAINT ref_v2_issue_type_map_pkey PRIMARY KEY (issue_type_code);
+
+INSERT INTO fds.ref_v2_issue_type_map (
+  issue_type_code,
+  issue_type_desc,
+  asset_class_code
+) VALUES
+  ('00', 'N/A', NULL),
+  ('BB', 'Bond', 'W'),
+  ('DD', 'Debenture', 'W'),
+  ('EE', 'Equity', 'X'),
+  ('02', 'Dual Listing', 'X'),
+  ('F2', 'Closed-End Mutual Fund', 'X'),
+  ('F1', 'Exchange Traded Fund', 'X'),
+  ('LL', 'Loan', 'Z'),
+  ('NN', 'Note', 'Z')
+  ;


### PR DESCRIPTION
Add a `docker-compose` file to spin up a testing database alongside the container for manual testing.

Also add some mock testing data in support of `get_issue_code_bridge()`

current testing steps:
```sh
docker-compose up
```
```
# in another terminal:
docker attach workflowfactset-workflow.factset-1 # enters the workflow.factset container
```
```r
#in that container
library(workflow.factset)
conn <- connect_factset_db()
issue_code_bridge <- get_issue_code_bridge(conn = conn)
issue_code_bridge
# A tibble: 9 × 5
#   issue_type_code issue_type_desc   asset_class_code asset_class_desc asset_type
#   <chr>           <chr>             <chr>            <chr>            <chr>
# 1 00              N/A               NA               NA               Other
# 2 BB              Bond              W                NA               Corporate…
# 3 DD              Debenture         W                NA               Corporate…
# 4 EE              Equity            X                Bond             Listed Eq…
# 5 02              Dual Listing      X                Bond             Listed Eq…
# 6 F2              Closed-End Mutua… X                Bond             Fund
# 7 F1              Exchange Traded … X                Bond             Fund
# 8 LL              Loan              Z                Other            Other
# 9 NN              Note              Z                Other            Corporate…
```

Closes: #41