### PR TITLE
Deploy/50 update deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If you do not create this file, then the deploy process will prompt for values.
 
 ```sh
 # change this value as needed.
-RESOURCEGROUP="myResourceGroup"
+RESOURCEGROUP="RMI-SP-PACTA-DEV"
 
 # run from repo root
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# workflow.pacta
+# workflow.factset
 
 This repo contains the `workflow.pacta` R package, a Dockerfile to build an image containing that package and its dependencies, and an Azure ARM template to deploy that image, along with [factset_data_loader](https://github.com/RMI-PACTA/factset_data_loader/) and a PostgreSQL database.
 
-**QUICKSTART**: See "Deploying" at the end of this file.
+**QUICKSTART**: See ["Deploy"](#Deploy), below.
 
 ## `workflow.factset` R package
 
@@ -137,18 +137,30 @@ Key variables to be aware of:
 Optional: Create a parameters file (`azure-deploy.example.parameters.json` serves as a template) for parameters that do not have a default.
 If you do not create this file, then the deploy process will prompt for values.
 
+A parameter file with the values that the RMI-PACTA team uses for extracting data is available at [`azure-deploy.rmi-pacta.parameters.json`](azure-deploy.rmi-pacta.parameters.json).
+
 ```sh
+# run from repo root
+
 # change this value as needed.
 RESOURCEGROUP="RMI-SP-PACTA-DEV"
 
-# run from repo root
+# Users with access to the RMI-PACTA Azure subscription can run:
+az deployment group create --resource-group "$RESOURCEGROUP" --template-file azure-deploy.json --parameters azure-deploy.rmi-pacta.parameters.json
 
+```
+
+For security, the RMI-PACTA parameters file makes heavy use of extracting secrets from an Azure Key vault, but an example file that passes parameters "in the clear" is available as [`azure-deploy.example.parameters.json`](azure-deploy.example.parameters.json)
+
+Non RMI-PACTA users can define their own parameters and invoke the ARM Template with:
+
+```sh
+# Otherwise:
 # Prompts for parameters without defaults
 az deployment group create --resource-group "$RESOURCEGROUP" --template-file azure-deploy.json 
 
-# or
+# if you have created your own parameters file:
 az deployment group create --resource-group "$RESOURCEGROUP" --template-file azure-deploy.json --parameters @azure-deploy.parameters.json
-
 ```
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ All parameters must have values, but most have sensible defaults already defined
 
 * `PGHOSTOverride`: If `updateDB` is `false`, then this specifies the value of `$PGHOST` environment variable that `workflow.factset` will connect to.
 * `PGPASSWORD`: Database Server Password
-* `containerGroupName`: Used to define the container group name, and by default the DB server name will have this appended with `-postgres`.
+* `containerGroupName`: Label to define the container group name, and by default the DB server name will have this appended with `-postgres`.
+    Does not affect behavior of container, but note for later, so resources can be deleted/managed via Azure Portal or through `az`.
 * `dataTimestamp`: Passed to containers as $DATA_TIMESTAMP environment variable.
 * `identity`: See "Identity" in "Prerequisites", above.
 * `imageTagLoader`: (default: `main`) tag used for `factset_data_loader` image from `ghcr.io`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # workflow.factset
 
-This repo contains the `workflow.pacta` R package, a Dockerfile to build an image containing that package and its dependencies, and an Azure ARM template to deploy that image, along with [factset_data_loader](https://github.com/RMI-PACTA/factset_data_loader/) and a PostgreSQL database.
+This repo contains the `workflow.factset` R package, a Dockerfile to build an image containing that package and its dependencies, and an Azure ARM template to deploy that image, along with [factset_data_loader](https://github.com/RMI-PACTA/factset_data_loader/) and a PostgreSQL database.
 
 **QUICKSTART**: See ["Deploy"](#Deploy), below.
 

--- a/azure-deploy.example.parameters.json
+++ b/azure-deploy.example.parameters.json
@@ -2,26 +2,54 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "identity": {
-      "value": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/resourceGroups/MyResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/MyManagedIdentity"
-    },
-    "storageAccountKeyRawdata": {
-      "value": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=="
-    },
-    "loaderFactsetSerial": {
-      "value": "123456"
-    },
-    "loaderFactsetUsername": {
-      "value": "FS_USER"
-    },
     "dataTimestamp": {
       "value": "20221231"
     },
     "issReportingYear": {
       "value": "2021"
     },
+
+    "identity": {
+    "value": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/resourceGroups/MYRESOURCEGROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/MyIdentity"
+    },
+
+    "storageAccountKeyExtracted": {
+      "value": "XXXXXXXX"
+    },
+    "storageAccountNameExtracted": {
+      "value": "mystorageaccount"
+    },
+    "storageAccountShareExtracted": {
+      "value": "factset-extracted"
+    },
+
+    "storageAccountKeyLoader": {
+      "value": "XXXXXXXX"
+    },
+    "storageAccountNameLoader": {
+      "value": "somestorageaccount"
+    },
+    "storageAccountShareLoader": {
+      "value": "loadershare"
+    },
+
+    "logWorkspaceId": {
+      "value": "XXXXXXXX"
+    },
+    "logWorkspaceKey": {
+      "value": "XXXXXXXX"
+    },
+
+    "loaderFactsetSerial": {
+      "value": "XXXXXXXX"
+    },
+    "loaderFactsetUsername": {
+      "value": "XXXXXXXX"
+    },
+
     "PGPASSWORD": {
-      "value": "Super5ecret!"
+      "value": "SuperSecret01!"
     }
+
   }
 }

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -120,13 +120,13 @@
       }
     },
 
-    "workspaceId": {
+    "logWorkspaceId": {
       "type": "string",
       "metadata": {
         "description": "The ID for a Log Analytics Workspace."
       }
     },
-    "workspaceKey": {
+    "logWorkspaceKey": {
       "type": "securestring",
       "metadata": {
         "description": "The key for a Log Analytics Workspace."
@@ -399,8 +399,8 @@
         "diagnostics": {
           "logAnalytics": {
             "logType": "ContainerInstanceLogs",
-            "workspaceId": "[parameters('workspaceId')]]",
-            "workspaceKey": "[parameters('workspaceKey')]"
+            "workspaceId": "[parameters('logWorkspaceId')]]",
+            "workspaceKey": "[parameters('logWorkspaceKey')]"
           }
         },
         "containers":

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -399,7 +399,7 @@
         "diagnostics": {
           "logAnalytics": {
             "logType": "ContainerInstanceLogs",
-            "workspaceId": "[parameters('logWorkspaceId')]]",
+            "workspaceId": "[parameters('logWorkspaceId')]",
             "workspaceKey": "[parameters('logWorkspaceKey')]"
           }
         },
@@ -415,18 +415,18 @@
           {
             "name": "factset-extracted",
             "azureFile": {
-              "shareName": "[parameters('storageAccountShareExtracted')]]",
+              "shareName": "[parameters('storageAccountShareExtracted')]",
               "readOnly": false,
-              "storageAccountName": "[parameters('storageAccountNameExtracted')]]",
+              "storageAccountName": "[parameters('storageAccountNameExtracted')]",
               "storageAccountKey": "[parameters('storageAccountKeyExtracted')]"
             }
           },
           {
             "name": "factset-loader",
             "azureFile": {
-              "shareName": "[parameters('storageAccountShareLoader')]]]",
+              "shareName": "[parameters('storageAccountShareLoader')]",
               "readOnly": false,
-              "storageAccountName": "[parameters('storageAccountNameLoader')]]",
+              "storageAccountName": "[parameters('storageAccountNameLoader')]",
               "storageAccountKey": "[parameters('storageAccountKeyLoader')]"
             }
           }

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -53,7 +53,7 @@
       "type": "string",
       "defaultValue": "[utcNow()]",
       "metadata": {
-        "description": "The time to start the container group."
+        "description": "The time this template is deployed."
       }
     },
 

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -32,7 +32,7 @@
     },
     "location": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
       }

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -106,12 +106,6 @@
         "description": "The time to start the container group."
       }
     },
-    "storageAccountKeyRawdata": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The storage account key for the rawdata storage account."
-      }
-    },
     "workspaceId": {
       "type": "string",
       "metadata": {
@@ -130,7 +124,47 @@
       "metadata": {
         "description": "Deploy Database and FDSLoader image to update the database."
       }
+    },
+
+
+    "storageAccountKeyExtracted": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The storage account key for the storage account for extracted files."
+      }
+    },
+    "storageAccountNameExtracted": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name for the storage account for extracted files."
+      }
+    },
+    "storageAccountShareExtracted": {
+      "type": "string",
+      "metadata": {
+        "description": "The file share name for the extracted files."
+      }
+    },
+
+    "storageAccountKeyLoader": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The storage account key for the storage account for factset_data_loader."
+      }
+    },
+    "storageAccountNameLoader": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name for the storage account for factset_data_loader."
+      }
+    },
+    "storageAccountShareLoader": {
+      "type": "string",
+      "metadata": {
+        "description": "The file share name for the factset_data_loader."
+      }
     }
+    
   },
 
   "variables": {
@@ -369,25 +403,25 @@
         "osType": "Linux",
         "volumes": [
           {
-            "name": "factset-extracted",
-            "azureFile": {
-              "shareName": "factset-extracted",
-              "readOnly": false,
-              "storageAccountName": "pactarawdata",
-              "storageAccountKey": "[parameters('storageAccountKeyRawdata')]"
-            }
-          },
-          {
             "name": "workingspace",
             "emptyDir": {}
           },
           {
+            "name": "factset-extracted",
+            "azureFile": {
+              "shareName": "[parameters('storageAccountShareExtracted')]]",
+              "readOnly": false,
+              "storageAccountName": "[parameters('storageAccountNameExtracted')]]",
+              "storageAccountKey": "[parameters('storageAccountKeyExtracted')]"
+            }
+          },
+          {
             "name": "factset-loader",
             "azureFile": {
-              "shareName": "factset-loader",
+              "shareName": "[parameters('storageAccountShareLoader')]]]",
               "readOnly": false,
-              "storageAccountName": "pactarawdata",
-              "storageAccountKey": "[parameters('storageAccountKeyRawdata')]"
+              "storageAccountName": "[parameters('storageAccountNameLoader')]]",
+              "storageAccountKey": "[parameters('storageAccountKeyLoader')]"
             }
           }
         ]

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -3,6 +3,60 @@
   "contentVersion": "0.0.0.5",
 
   "parameters": {
+
+    "containerGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the container group."
+      }
+    },
+
+    "dataTimestamp": {
+      "type": "string",
+      "metadata": {
+        "description": "The time to start the container group."
+      }
+    },
+    "issReportingYear": {
+      "type": "string",
+      "metadata": {
+        "description": "Reporting year to use for ISS data."
+      }
+    },
+
+    "identity": {
+      "type": "string",
+      "metadata": {
+        "description": "The ID of the user assigned identity to use for the container group."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "restartPolicy": {
+      "type": "string",
+      "defaultValue": "Never",
+      "allowedValues": [
+        "Always",
+        "Never",
+        "OnFailure"
+      ],
+      "metadata": {
+        "description": "The behavior of Azure runtime if container has stopped."
+      }
+    },
+    "starttime": {
+      "type": "string",
+      "defaultValue": "[utcNow()]",
+      "metadata": {
+        "description": "The time to start the container group."
+      }
+    },
+
     "PGHOSTOverride": {
       "type": "string",
       "defaultValue": "",
@@ -16,30 +70,7 @@
         "description": "password to connect to database"
       }
     },
-    "containerGroupName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the container group."
-      }
-    },
-    "dataTimestamp": {
-      "type": "string",
-      "metadata": {
-        "description": "The time to start the container group."
-      }
-    },
-    "identity": {
-      "type": "string",
-      "metadata": {
-        "description": "The ID of the user assigned identity to use for the container group."
-      }
-    },
-    "issReportingYear": {
-      "type": "string",
-      "metadata": {
-        "description": "Reporting year to use for ISS data."
-      }
-    },
+
     "imageTagLoader": {
       "type": "string",
       "defaultValue": "main",
@@ -54,6 +85,7 @@
         "description": "Image tag for the workflow container."
       }
     },
+
     "loaderDBBackup": {
       "type": "string",
       "defaultValue": "1",
@@ -80,32 +112,14 @@
         "description": "Username provided by FactSet"
       }
     },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
+    "updateDB": {
+      "type": "bool",
+      "defaultValue": true,
       "metadata": {
-        "description": "Location for all resources."
+        "description": "Deploy Database and FDSLoader image to update the database."
       }
     },
-    "restartPolicy": {
-      "type": "string",
-      "defaultValue": "Never",
-      "allowedValues": [
-        "Always",
-        "Never",
-        "OnFailure"
-      ],
-      "metadata": {
-        "description": "The behavior of Azure runtime if container has stopped."
-      }
-    },
-    "starttime": {
-      "type": "string",
-      "defaultValue": "[utcNow()]",
-      "metadata": {
-        "description": "The time to start the container group."
-      }
-    },
+
     "workspaceId": {
       "type": "string",
       "metadata": {
@@ -118,14 +132,6 @@
         "description": "The key for a Log Analytics Workspace."
       }
     },
-    "updateDB": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Deploy Database and FDSLoader image to update the database."
-      }
-    },
-
 
     "storageAccountKeyExtracted": {
       "type": "securestring",

--- a/azure-deploy.rmi-pacta.parameters.json
+++ b/azure-deploy.rmi-pacta.parameters.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataTimestamp": {
+      "value": "20221231"
+    },
+    "issReportingYear": {
+      "value": "2021"
+    },
+
+    "identity": {
+      "value": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pacta-runner-dev"
+    },
+
+    "storageAccountKeyExtracted": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "rawdata-storageaccountkey"
+      }
+    },
+    "storageAccountNameExtracted": {
+      "value": "pactarawdata"
+    },
+    "storageAccountShareExtracted": {
+      "value": "factset-extracted"
+    },
+
+    "storageAccountKeyLoader": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "rawdata-storageaccountkey"
+      }
+    },
+    "storageAccountNameLoader": {
+      "value": "pactarawdata"
+    },
+    "storageAccountShareLoader": {
+      "value": "factset-loader"
+    },
+
+    "logWorkspaceId": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "LogWorkspaceID-Dev"
+      }
+    },
+    "logWorkspaceKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "LogWorkspaceKey-Dev"
+      }
+    },
+
+    "loaderFactsetSerial": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "factset-serial"
+      }
+    },
+    "loaderFactsetUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "factset-username"
+      }
+    },
+
+    "PGPASSWORD": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.KeyVault/vaults/pacta-vault-dev"
+        },
+        "secretName": "factset-database-password"
+      }
+    }
+
+  }
+}

--- a/azure-deploy.rmi-pacta.parameters.json
+++ b/azure-deploy.rmi-pacta.parameters.json
@@ -2,12 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "dataTimestamp": {
-      "value": "20221231"
-    },
-    "issReportingYear": {
-      "value": "2021"
-    },
 
     "identity": {
       "value": "/subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/RMI-SP-PACTA-DEV/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pacta-runner-dev"


### PR DESCRIPTION
This PR updates t he deploy script and documentation, to account for changes in RMI's Azure infrastructure.

Of particular note is the `azure-deploy.rmi-pacta.parameters.json` file, which, if called as part of the `az deployment create` command (See updated README), will allow members of the RMI Active Directory with correct permissions (@cjyetman, @jdhoffa, and @AlexAxthelm ) to deploy a container instance which handle connecting to our Azure File Shares and deploying and authenticating to a Postgres database correctly, leaving`data_timestamp` and `iss_reporting_year` as the important parameters to be entered manually.