### PR TITLE
ci/51 multiple timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ All parameters must have values, but most have sensible defaults already defined
 * `PGPASSWORD`: Database Server Password
 * `containerGroupName`: Used to define the container group name, and by default the DB server name will have this appended with `-postgres`.
 * `dataTimestamp`: Passed to containers as $DATA_TIMESTAMP environment variable.
+  * This parameter can accept a comma separated list (`20221231,20231231`) to allow for multiple instance of `workflow.factset` to run simultaneously.
 * `identity`: See "Identity" in "Prerequisites", above.
 * `imageTagLoader`: (default: `main`) tag used for `factset_data_loader` image from `ghcr.io`
 * `imageTagWorkflow`: (default: `main`) tag used for `workflow.pacta` image from `ghcr.io`
@@ -138,6 +139,11 @@ Optional: Create a parameters file (`azure-deploy.example.parameters.json` serve
 If you do not create this file, then the deploy process will prompt for values.
 
 A parameter file with the values that the RMI-PACTA team uses for extracting data is available at [`azure-deploy.rmi-pacta.parameters.json`](azure-deploy.rmi-pacta.parameters.json).
+
+Note: the `dataTimestamp` and `issReportingYear` parameters accept comma separated lists (which must be of equal length).
+For example: `20221231,20231231` and `2021,2022`.
+If deployed with such parameters, the deploy template will include a container running `workflow.factset` for each index pair (`20221231` with reporting year `2021`, and `20231231` with `2022`).
+
 
 ```sh
 # run from repo root

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -187,22 +187,29 @@
     "dbServerName": "[concat(parameters('containerGroupName'), '-postgres')]",
     "dbSkuSizeGB": 512,
     "machineCpuCoresLimitLoader": 3,
-    "machineCpuCoresLimitWorkflow": 2,
-    "machineCpuCoresRequestLoader": 2,
-    "machineCpuCoresRequestWorkflow": 1,
+    "machineCpuCoresLimitWorkflow": "[div(4, length(variables('dataTimestampArray')))]",
+    "machineCpuCoresRequestLoader": 1,
+    "machineCpuCoresRequestWorkflow": "[max(1, div(3, length(variables('dataTimestampArray'))))]",
     "machineMemoryInGBLimitLoader": 6,
-    "machineMemoryInGBLimitWorkflow": 16,
+    "machineMemoryInGBLimitWorkflow": "[div(16, length(variables('dataTimestampArray')))]",
     "machineMemoryInGBRequestLoader": 4,
-    "machineMemoryInGBRequestWorkflow": 12,
+    "machineMemoryInGBRequestWorkflow": "[div(12, length(variables('dataTimestampArray')))]",
     "mountPathExport": "/mnt/factset-extracted",
     "mountPathFDSLoader": "/mnt/factset-loader",
     "mountPathWorkingSpace": "/mnt/workingspace",
     "postgresVersion": "14",
 
+
+    "dataTimestampArray" : "[split(parameters('dataTimestamp'), ',')]",
+    "issReportingYearArray" : "[split(parameters('issReportingYear'), ',')]",
+
     "emptyArray": [],
-    "ContainerDefinitionWorkflow":[
+    "copy": [
       {
-        "name": "workflow-factset",
+      "name": "ContainerDefinitionWorkflow",
+      "count": "[length(variables('dataTimestampArray'))]",
+      "input": {
+        "name": "[toLower(concat('workflow-factset', padLeft(copyIndex('ContainerDefinitionWorkflow'), 2, '0')))]",
         "properties": {
           "image": "[concat(variables('containerregistry'),'/workflow.factset:', parameters('imageTagWorkflow'))]",
           "ports": [],
@@ -251,11 +258,11 @@
             },
             {
               "name": "DATA_TIMESTAMP",
-              "value": "[parameters('dataTimestamp')]"
+              "value": "[variables('dataTimestampArray')[copyIndex('ContainerDefinitionWorkflow')]]"
             },
             {
               "name": "ISS_REPORTING_YEAR",
-              "value": "[parameters('issReportingYear')]"
+              "value": "[variables('issReportingYearArray')[copyIndex('ContainerDefinitionWorkflow')]]"
             },
             {
               "name": "UPDATE_DB",
@@ -277,6 +284,7 @@
             }
           ]
         }
+      }
       }
     ],
     "ContainerDefinitionLoader": [


### PR DESCRIPTION
Provides mechanism for running multiple instances of `workflow.factset` (not `factset_data_loader`) simultaneously, as part of a single deployment. The instances will both pull from the same database, but with different data timestamps or iss reporting dates.

if run with dataTimestamp `"20221231,20231231"` and issReportingYear `2021,2022`, the deploy template will include a container running `workflow.factset` for each index pair (`20221231` with reporting year `2021`, and `20231231` with `2022`).

Suggest resolving #50 first, since this is a branch of that, though it could be rebased from `main` without too much difficulty.

I have deployed sucessfully, and am submitting this PR while I wait for results.